### PR TITLE
Fix Windows Installer Build Failed Due to Haskell Package Version Mismatch

### DIFF
--- a/nix/internal/x86_64-windows.nix
+++ b/nix/internal/x86_64-windows.nix
@@ -501,7 +501,7 @@ in rec {
       inherit (pkgs) system;
     };
   in
-    pkgs.haskell.lib.justStaticExecutables hsDaedalusPkgs.daedalus-installer;
+    pkgsJs.haskell.lib.justStaticExecutables hsDaedalusPkgs.daedalus-installer;
 
   nsisFiles = genClusters (cluster:
     pkgs.runCommand "nsis-files" {


### PR DESCRIPTION
Fixes build failure in `nix build -L .#installer-mainnet-x86_64-windows` (and other Windows installer targets) where the Nix evaluation fails with:

```
error: function 'anonymous lambda' called with unexpected argument 'disallowGhcReference'
```

## Root Cause

The Windows installer build uses Haskell packages from two different nixpkgs versions simultaneously, causing API incompatibility:

1. **`pkgsJs`** — based on `nixpkgs-22.11-darwin` (from 2022) — used to build the `daedalus-installer` Haskell package
2. **`pkgs`** — based on `nixos-25.11` (from 2025) — provides the Haskell builder utilities

The problematic code in [`nix/internal/x86_64-windows.nix:504`](nix/internal/x86_64-windows.nix#L504) was:

```nix
make-installer = let
  hsDaedalusPkgs = import ../../installers {
    pkgs = pkgsJs;  # Build with old nixpkgs (22.11)
    inherit (pkgs) system;
  };
in
  pkgs.haskell.lib.justStaticExecutables hsDaedalusPkgs.daedalus-installer;
  # ↑ Use new nixpkgs (25.11) utilities on old package
```

The `pkgs.haskell.lib` from nixos-25.11 expects a `disallowGhcReference` parameter that doesn't exist in the package structure built with nixpkgs-22.11, resulting in the build error.

## Solution

Use `pkgsJs.haskell.lib` instead of `pkgs.haskell.lib` to match the Haskell builder utilities version with the nixpkgs version that built the package:

```nix
make-installer = let
  hsDaedalusPkgs = import ../../installers {
    pkgs = pkgsJs;  # Build with old nixpkgs (22.11)
    inherit (pkgs) system;
  };
in
  pkgsJs.haskell.lib.justStaticExecutables hsDaedalusPkgs.daedalus-installer;
  # ↑ Use matching utilities from same nixpkgs version
```

## Changes

- **File**: [`nix/internal/x86_64-windows.nix`](nix/internal/x86_64-windows.nix)
- **Line**: 504
- **Change**: `pkgs.haskell.lib` → `pkgsJs.haskell.lib`

## Testing

Building Windows installers now works correctly:

```bash
nix build -L .#installer-mainnet-x86_64-windows
nix build -L .#installer-preprod-x86_64-windows
nix build -L .#installer-preview-x86_64-windows
```

## Type of Change

- [x] Bug fix (fixes build failure)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issues

Fixes build failure in Windows installer generation on branch `mithril` (and potentially other branches depending on nixpkgs versions).

