### PR TITLE
fix(nix): exclude markdown docs except terms-of-use assets from build

### DIFF
--- a/nix/internal/common.nix
+++ b/nix/internal/common.nix
@@ -227,7 +227,8 @@
       ))
       # Exclude specific files
       && !(baseName == ".envrc")
-      && !(pkgs.lib.hasSuffix ".md" name && type == "regular");
+      # Exclude markdown docs but keep terms-of-use .md files (runtime assets loaded by webpack)
+      && !(pkgs.lib.hasSuffix ".md" name && type == "regular" && !(pkgs.lib.hasInfix "/terms-of-use/" name));
   };
 
   # This is the only thing we use the original `yarn2nix` for:


### PR DESCRIPTION
Issue where the build errored out because of missing markdown assets for the terms-of-use page. The latest nix config updates included a block on all `.md` files, but this specific asset required the `.md` allowance.

<img width="3102" height="1718" alt="image" src="https://github.com/user-attachments/assets/977fe896-d59c-4fc6-baad-4efafcc5863b" />
